### PR TITLE
feat: cache introspect results in lru cache

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,12 @@ const boom = require('boom')
 const joi = require('joi')
 const jwkToPem = require('jwk-to-pem')
 
+const cacheObject = joi.object({
+  cache: joi.string(),
+  segment: joi.string().default('keycloakJwt'),
+  expiresIn: joi.number()
+})
+
 /**
  * @type Object
  * @private
@@ -31,12 +37,11 @@ const scheme = joi.object({
   minTimeBetweenJwksRequests: joi.number().integer().positive().allow(0).default(0)
     .description('The minimum time between JWKS requests in seconds')
     .example(15),
-  cache: joi.alternatives().try(joi.object({
-    cache: joi.string(),
-    segment: joi.string().default('keycloakJwt'),
-    expiresIn: joi.number()
-  }), joi.boolean()).default(false)
+  cache: joi.alternatives().try(cacheObject, joi.boolean()).default(false)
     .description('The configuration of the hapi.js cache powered by catbox')
+    .example('true'),
+  lruCache: joi.alternatives().try(cacheObject, joi.boolean()).default(false)
+    .description('The configuration of the hapi.js lru cache powered by catbox')
     .example('true'),
   userInfo: joi.array().items(joi.string().min(1))
     .description('List of properties which should be included in the `request.auth.credentials` object')


### PR DESCRIPTION
<!--
Title:
<jira card>: <brief description>

Example:
SS-4242: Users were unable to login.

Without card:
<type of fix>: <short summary>

Example:
fix(users): issue sign up request to Keycloak on user sign up
-->

<!--
Short summary of what is being done.
Complete sentence, written as though it was an order.
Follow by empty line.

Example:
fix(users): issue sign up request to Keycloak on user sign up
-->
### Summary
Token introspection results can optionally be cached in lruStore. This store is meant to have a small TTL

<!--
Informative description of what is being solved and why this approach was used.

Provide any relevant information: PR dependencies, unit tests, etc.

Example:
Users were unable to sign up due to API not issuing a request to the Keycloak server. This created
an entry in DB but not in Keycloak server.
-->
### Description

<!--
Additional Links such as jira cards which can be auto linked by Jira bot with format of: <project>-<number>.

Example:
[SS-4242]
-->
### Additional Links
